### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/js/mods-model.js
+++ b/js/mods-model.js
@@ -537,7 +537,7 @@ var OSWSModsResult = Class.extend({
                     .append($('<span>')
                         .html(doi)
                         .css({'white-space': 'nowrap'}))
-                    .attr('href', 'https://dx.doi.org/' + doi)
+                    .attr('href', 'https://doi.org/' + doi)
                     .attr('target', 'doi')
                     .attr('title', 'Go to resolved Doi'))
         })();

--- a/mods-model.js
+++ b/mods-model.js
@@ -536,7 +536,7 @@ var OSWSModsResult = Class.extend({
                     .append($('<span>')
                         .html(doi)
                         .css({'white-space': 'nowrap'}))
-                    .attr('href', 'https://dx.doi.org/' + doi)
+                    .attr('href', 'https://doi.org/' + doi)
                     .attr('target', 'doi')
                     .attr('title', 'Go to resolved Doi'))
         })();


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but I'd hereby like to suggest to follow the new recommendation and update the code that generates new DOI links.

Cheers!